### PR TITLE
fix: use local zkevm main

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topos-protocol/topos-zkevm-demo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Topos zkEVM demo",
   "bin": {
     "topos-zkevm-demo": "dist/main.js"

--- a/src/commands/install.command.ts
+++ b/src/commands/install.command.ts
@@ -6,7 +6,7 @@ import { satisfies } from 'semver'
 import { log, logError, logToFile } from '../loggers'
 import { Next, ReactiveSpawn } from '../ReactiveSpawn'
 
-const LOCAL_ZKEVM_REF = 'feat/stateless'
+const LOCAL_ZKEVM_REF = 'main'
 const ZERO_BIN_REF = 'main'
 const MIN_VERSION_DOCKER = '17.6.0'
 const MIN_VERSION_GIT = '2.0.0'


### PR DESCRIPTION
# Description

This PR fixes the `local-zkevm` branch used in the `install` command so that the CLI installs the `main` branch.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
